### PR TITLE
Fix slots and signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For easy usage of the Signals and Slots, there are a few generic macros which sh
 ## Include Events
 
 ```c++
-#include "Events.h"
+#include "Event.h"
 
 void setup() {
 
@@ -133,7 +133,7 @@ EVENT_CONNECT(signal, slot_or_signal);
 Example: Connect Signal to Slot
 
 ```c++
-#include "Events.h"
+#include "Event.h"
 
 Base sender;
 Base receiver;
@@ -151,7 +151,7 @@ To send data between signal and slot, there are two possibilities. Each signal i
 Example: Emit Signals
 
 ```c++
-#include "Events.h"
+#include "Event.h"
 
 Base sender;
 Base receiver;

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -102,7 +102,7 @@ void setup() {
 
   //Test3: Redirect Signal over another sigenl: Connect Signal_1 to Signal_2 and then Singal_2 to Signal_3;
   EVENT_CONNECT(emiter.m_redirect_signal,secondReceiver.m_onRedirect_signal);
-  EVENT_CONNECT(secondReceiver.m_onRedirect_signal,emiter.m_redirect_signal);
+  EVENT_CONNECT(secondReceiver.m_onRedirect_signal,receiver.m_onRedirect_slot);
 
   //Test4: Signal Slot without any parameter
   EVENT_CONNECT(emiter.m_voidTest_signal,receiver.m_voidTest_slot);

--- a/include/Event.h
+++ b/include/Event.h
@@ -8,7 +8,7 @@
 #elif (EVENT_USE_CPP_DEV_TYPE == EVENT_TYPE_STANDARD)
     #include "EventSignalLst.h"
 #else 
-    #error "!!!!Invlaid EVENT_USE_CPP_DEV_TYPE set!!!!"
+    #error "!!!!Invalid EVENT_USE_CPP_DEV_TYPE set!!!!"
 #endif
 
 #include "EventSlot.h"
@@ -23,7 +23,7 @@
     EXPAND_AND_CONCAT(EVENT_SIGNAL_PREFIX , __name__, EVENT_SIGNAL_SUFFIX)
 
 #define EVENT_RESOLVE_SLOT(__name__) \
-
+    EXPAND_AND_CONCAT(EVENT_SLOT_PREFIX , __name__, EVENT_SLOT_SUFFIX)
 #define EVENT_SIGNAL(__name__,args...)                                              \
     EventSignal<args> EXPAND_AND_CONCAT(EVENT_SIGNAL_PREFIX , __name__, EVENT_SIGNAL_SUFFIX)
 
@@ -105,4 +105,4 @@ template <class... T> using EventFncSlot = FunctionSlot<T...>;
 
 
 
-#endif // CALLBACK_H
+#endif // EVENT_H

--- a/include/EventSignalLst.h
+++ b/include/EventSignalLst.h
@@ -26,7 +26,7 @@ public:
     /**
      * @brief Construct a new Signal object
      */
-    Signal(uint16_t max_connections = UINT16_MAX) : m_max_onnections(max_connections),
+    Signal(uint16_t max_connections = UINT16_MAX) : m_max_connections(max_connections),
                                                     m_size_of_connections(0)
     {
         /*All list are initiated whith null to reduce RAM usage*/
@@ -41,8 +41,16 @@ public:
      */
     virtual ~Signal()
     {
-        m_connected_slots->clear();
-        m_connected_signals->clear();
+        if (m_connected_slots != nullptr)
+        {
+            delete m_connected_slots;
+            m_connected_slots = nullptr;
+        }
+        if (m_connected_signals != nullptr)
+        {
+            delete m_connected_signals;
+            m_connected_signals = nullptr;
+        }
     }
 
     /**
@@ -59,7 +67,7 @@ public:
             m_connected_signals = new std::vector<Signal<Type...> *>();
         }
 
-        if (m_size_of_connections < m_max_onnections)
+        if (m_size_of_connections < m_max_connections)
         {
             m_connected_signals->push_back((Signal<Type...> *)&signal);
             m_size_of_connections++;
@@ -79,7 +87,7 @@ public:
             m_connected_slots = new std::vector<Slot<Type...> *>();
         }
 
-        if (m_size_of_connections < m_max_onnections)
+        if (m_size_of_connections < m_max_connections)
         {
             m_connected_slots->push_back((Slot<Type...> *)&slot);
             m_size_of_connections++;
@@ -102,7 +110,7 @@ public:
             {
                 if (&slot == m_connected_slots->at(i))
                 {
-                    m_connected_slots->erase(i);
+                    m_connected_slots->erase(m_connected_slots->begin() + i);
                     m_size_of_connections--;
                     found = true;
                 }
@@ -125,7 +133,7 @@ public:
             {
                 if (&signal == m_connected_signals->at(i))
                 {
-                    m_connected_signals->erase(i);
+                    m_connected_signals->erase(m_connected_signals->begin() + i);
                     m_size_of_connections--;
                     found = true;
                 }
@@ -169,7 +177,7 @@ public:
     }
 
 private:
-    uint16_t m_max_onnections;                           /*!< */
+    uint16_t m_max_connections;                          /*!< */
     uint16_t m_size_of_connections;                      /*!< */
     std::vector<Slot<Type...> *> *m_connected_slots;     /*!< */
     std::vector<Signal<Type...> *> *m_connected_signals; /*!< */


### PR DESCRIPTION
## Summary
- fix README include instructions
- correct slot macro resolution in Event.h
- fix typos and header guard comment
- improve memory handling for EventSignalLst
- fix example to avoid signal loops

## Testing
- `g++ -std=c++17 -Iinclude build/test.cpp -o build/test && ./build/test`

------
https://chatgpt.com/codex/tasks/task_e_6876b4721a088322ab6d82fbebbe4fad